### PR TITLE
Add username frontend validation in /sign-up

### DIFF
--- a/frontend/app/(auth)/sign-up/page.tsx
+++ b/frontend/app/(auth)/sign-up/page.tsx
@@ -27,6 +27,9 @@ const SignUpSchema = z.object({
     .min(5, {
       message: "Username must be at least 5 characters."
     })
+    .regex(/^[a-z0-9_-]+$/, {
+      message: "Username can only contain a-z, 0-9, _, and -."
+    })
     .refine(async (username) => {
       try {
         await axios.post("http://localhost:8080/api/check-username-exists", { username });


### PR DESCRIPTION
- Allow to register for username with only `a-z`, `0-9`, `_`, and `-`. 