### PR TITLE
Rename Response to GroqResponse

### DIFF
--- a/backend/handlers/groq.go
+++ b/backend/handlers/groq.go
@@ -79,7 +79,7 @@ func GetGroqResponse(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"message": err.Error()})
 	}
 
-	var res models.Response
+	var res models.GroqResponse
 	err = json.Unmarshal(body, &res)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"message": err.Error()})

--- a/backend/models/groq.go
+++ b/backend/models/groq.go
@@ -18,6 +18,6 @@ type Choice struct {
 	Message Message `json:"message"`
 }
 
-type Response struct {
+type GroqResponse struct {
 	Choices []Choice `json:"choices"`
 }


### PR DESCRIPTION
- Renamed struct from `Response` to `GroqResponse` to avoid potential issues with regular response