### PR TITLE
Set min length for password form

### DIFF
--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -81,6 +81,7 @@ export default function Login() {
                     <FormControl>
                       <div className="relative w-full">
                         <Input
+                          minLength={8}
                           autoComplete="current-password"
                           type={showPassword ? "text" : "password"}
                           {...field}

--- a/frontend/app/(auth)/sign-up/page.tsx
+++ b/frontend/app/(auth)/sign-up/page.tsx
@@ -108,6 +108,7 @@ export default function SignUp() {
                     <FormControl>
                       <div className="relative w-full">
                         <Input
+                          minLength={8}
                           autoComplete="new-password"
                           type={showPassword ? "text" : "password"}
                           {...field}


### PR DESCRIPTION
- Added `minLength={8}` for password forms in /login and /sign-up