### PR TITLE
Fix runtime error in PostCard

### DIFF
--- a/frontend/components/right-sidebar/PostCard.tsx
+++ b/frontend/components/right-sidebar/PostCard.tsx
@@ -73,7 +73,7 @@ const PostCard = () => {
             <div className="h-full">
               <Avatar>
                 <AvatarFallback>
-                  {currentUser?.accountName.substring(0, 1).toUpperCase()}
+                  {currentUser?.accountName?.substring(0, 1).toUpperCase()}
                 </AvatarFallback>
               </Avatar>
             </div>


### PR DESCRIPTION
- Added `?` to accountName since it could be null